### PR TITLE
Avoid recursively loading babelrc or babel config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,8 @@ function transformExtension(filepath, extMapping) {
   return filepath;
 }
 const astTransformExtension = parseSync(
-  `(${transformExtension.toString()})`
+  `(${transformExtension.toString()})`,
+  { babelrc: false, configFile: false }
 ).program.body[0].expression;
 
 


### PR DESCRIPTION
In a certain configuration I observe the following error:

````
Error: [BABEL]: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
```
babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
```
````

(More specifically, this is observed in my [yarn v3-based project](https://github.com/wantedly/hi18n/tree/227bbfc60a2329bcf4a3b819704bf1de261a2f53) when [the patch line](https://github.com/wantedly/hi18n/blob/227bbfc60a2329bcf4a3b819704bf1de261a2f53/package.json#L33) is removed from the root `package.json` and `yarn build` is run.)

This is likely caused by the plugin asking `parseSync` to look up babelrc and configFile recursively. This PR turns off the unnecessary config loading to fix the problem.