### PR TITLE
feat: replace dynamic import extensions at compile-time + fix: avoid duplicate injections

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export { bar } from './module2.mjs';
 
 // In dynamic import, function to replace extension is inserted.
 // Note the actual code is not exactly the same.
-const promise = import(transformExtension('./module3' + '.js'));
+const promise = import(__transformExtension('./module3' + '.js'));
 ```
 
 ## Why We Need This Plugin?
@@ -41,7 +41,7 @@ of the code, there is two ways to tell Node which file is which version.
   with a `type` field specified to the directory.
 
 If you choose the former and you write your code in ESModule and transpile it
-to CommonJS, you have to change the extension of the files while transpiling. 
+to CommonJS, you have to change the extension of the files while transpiling.
 
 In Babel CLI, extension of the output file name can be changed with
 `--out-file-extension` option. But the file name referenced inside the code
@@ -88,6 +88,46 @@ be done by Babel config of
 ```
 Once again, `--out-file-extension` option must be used together to change the
 output file extension.
+
+## Supporting both `mjs` and `cjs` in the same package
+
+If you are using `.mjs` for your source files, you can use babel to generate `.cjs` files for backwards compatibility:
+
+```json
+{
+  "presets": [["@babel/env"]],
+  "plugins": [
+    ["replace-import-extension", { "extMapping": { ".mjs": ".cjs" }}]
+  ]
+}
+```
+
+In your `package.json` specify the entries accordingly:
+
+```json
+{
+  "main": "dist/index.cjs",
+  "module": "src/index.mjs",
+  "source": "src/index.mjs",
+  "exports": {
+    ".": {
+      "require": "dist/index.cjs",
+      "import": "src/index.mjs"
+    },
+    "src/index.mjs": {
+      "import": "src/index.mjs"
+    },
+    "dist/index.cjs": {
+      "require": "dist/index.cjs",
+      "import": "dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build.cjs": "babel -d dist/ src/ --out-file-extension .cjs",
+    "prepare": "npm run build.cjs"
+  }
+}
+```
 
 ## Options
 ### `extMapping`

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@
 const { parseSync } = require('@babel/core');
 
 
-function transformExtension(filepath, extMapping) {
+function __transformExtension(filepath, extMapping) {
   if(!filepath.startsWith('./') && !filepath.startsWith('../')) {
     // Package import
     return filepath;
@@ -42,11 +42,13 @@ function transformExtension(filepath, extMapping) {
   }
   return filepath;
 }
+
 const astTransformExtension = parseSync(
-  `(${transformExtension.toString()})`,
+  `(${__transformExtension.toString()})`,
   { babelrc: false, configFile: false }
 ).program.body[0].expression;
 
+const transFormExtensionInjections = new Set();
 
 function getOption(state, key) {
   const opts = state.opts || {};
@@ -64,7 +66,7 @@ module.exports = function({ types: t }) {
         }
         const source = path.node.source;
 
-        source.value = transformExtension(source.value, extMapping);
+        source.value = __transformExtension(source.value, extMapping);
       },
       // For re-exporting
       'ExportNamedDeclaration|ExportAllDeclaration'(path, state) {
@@ -77,7 +79,7 @@ module.exports = function({ types: t }) {
           return;
         }
 
-        source.value = transformExtension(source.value, extMapping);
+        source.value = __transformExtension(source.value, extMapping);
       },
       // For dynamic import
       CallExpression(path, state) {
@@ -100,14 +102,22 @@ module.exports = function({ types: t }) {
 
         // transform the string directly if it ends with an constant extension
         if (argument.type === 'StringLiteral' && /\.(\w+)$/.test(argument.node.value)) {
-          argument.node.value = transformExtension(argument.node.value, extMapping);
+          argument.node.value = __transformExtension(argument.node.value, extMapping);
           return;
         }
 
-        // otherwise inject the transform function into the code
-        // TODO: avoid injecting the transform function multiple times
+        // find the top-level scope
+        const programPath = path.findParent(path => path.isProgram());
+
+        if (!transFormExtensionInjections.has(programPath)) {
+          // inject at the the top-level scope
+          programPath.unshiftContainer('body', astTransformExtension);
+          transFormExtensionInjections.add(programPath);
+        }
+
+        // call the transform function
         argument.replaceWith(t.callExpression(
-          astTransformExtension, [argument.node, astExtMapping]
+          t.identifier('__transformExtension'), [argument.node, astExtMapping]
         ));
       },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -81,8 +81,6 @@ module.exports = function({ types: t }) {
       },
       // For dynamic import
       CallExpression(path, state) {
-        // TODO: Implement dynamic import
-
         const opts = state.opts || {};
         const extMapping = opts.extMapping;
         if(!extMapping) {
@@ -99,6 +97,15 @@ module.exports = function({ types: t }) {
         );
 
         const argument = path.get('arguments.0');
+
+        // transform the string directly if it ends with an constant extension
+        if (argument.type === 'StringLiteral' && /\.(\w+)$/.test(argument.node.value)) {
+          argument.node.value = transformExtension(argument.node.value, extMapping);
+          return;
+        }
+
+        // otherwise inject the transform function into the code
+        // TODO: avoid injecting the transform function multiple times
         argument.replaceWith(t.callExpression(
           astTransformExtension, [argument.node, astExtMapping]
         ));

--- a/test.js
+++ b/test.js
@@ -93,6 +93,21 @@ describe('src/index.js', () => {
     expect(code).toContain('require("./module.mjs")');
   });
 
+
+  test('extension in dynamic import with a string literal is correctly replaced', () => {
+    const input = 'import("./module.ext");';
+    const options = { extMapping: { '.ext': '.mjs' } };
+    let code = transform(input, options);
+    assertDynamicImportArgument(code, ['./module.mjs']);
+  });
+
+  test('extension in dynamic import with an interpolated single literal is correctly replaced', () => {
+    const input = 'import("./{some_variable}-module.ext");';
+    const options = { extMapping: { '.ext': '.mjs' } };
+    let code = transform(input, options);
+    assertDynamicImportArgument(code, ['./{some_variable}-module.mjs']);
+  });
+
   test('extension in dynamic import is correctly replaced', () => {
     const input = 'import("./module" + ".ext");';
     const options = { extMapping: { '.ext': '.mjs' } };

--- a/test.js
+++ b/test.js
@@ -26,11 +26,15 @@ function transform(input, options) {
 }
 
 function assertDynamicImportArgument(code, expected){
-  code = code.replace('import(', 'import_(');
+  code = code.replaceAll('import(', 'import_(');
   const import_ = jest.fn();
   new Function('import_', code)(import_);
   for(let [idx, e] of expected.entries())
     expect(import_).toHaveBeenNthCalledWith(idx + 1, e);
+}
+
+function transformExtensionDefinitions(code) {
+  return code.split('\n').filter(line => line.includes('function __transformExtension')).length;
 }
 
 describe('src/index.js', () => {
@@ -113,6 +117,15 @@ describe('src/index.js', () => {
     const options = { extMapping: { '.ext': '.mjs' } };
     let code = transform(input, options);
     assertDynamicImportArgument(code, ['./module.mjs']);
+    expect(transformExtensionDefinitions(code)).toBe(1);
+  });
+
+  test('extensions in multiple dynamic imports are correctly replaced', () => {
+    const input = 'import("./module1" + ".ext"); import("./module2" + ".ext");';
+    const options = { extMapping: { '.ext': '.mjs' } };
+    let code = transform(input, options);
+    assertDynamicImportArgument(code, ['./module1.mjs', './module2.mjs']);
+    expect(transformExtensionDefinitions(code)).toBe(1);
   });
 
   test('multiple dot extension is correctly replaced', () => {


### PR DESCRIPTION
- If the dynamic import is a string literal with a constant extension, its path is replaced at compile-time instead of injecting code.
- Now, the `__transformExtension` function is only injected once for multiple dynamic imports. 

These two features reduce the output size significantly for dynamic imports.

Fixes #8 